### PR TITLE
fix: workflows not appearing in the status-checks dropdown

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,6 +16,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.github.com:443
             github.com:443
 
       - name: Checkout

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on: [ push, pull_request ]
 
 jobs:
   build:
+    name: run tests
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   release:
+    name: test release
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
set names for our workflows so we can use them as status checks in the branch protection rules